### PR TITLE
feat: make ccr start run in background by default (v1.1.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccr-next",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Use Claude Code without an Anthropics account and route it to another LLM provider",
   "bin": {
     "ccr": "dist/cli.js"


### PR DESCRIPTION
## Summary
- Changed default behavior of `ccr start` to run in background
- Added `--foreground` flag for running in foreground mode  
- Fixed service detection issues
- Bumped version to 1.1.2

## Changes
1. **Background by default**: `ccr start` now spawns a detached process and returns immediately
2. **Foreground option**: Use `ccr start --foreground` to run in the terminal (old behavior)
3. **Better status feedback**: Shows a spinner while starting and displays status after successful start
4. **Already running check**: Prevents multiple instances and shows current status if already running

## Breaking Change
⚠️ `ccr start` now runs in background by default. Use `--foreground` flag to run in foreground mode.

## Test plan
- [x] Built and tested locally
- [x] Verified `ccr start` runs in background
- [x] Verified `ccr start --foreground` runs in foreground
- [x] Verified `ccr status` correctly detects running service
- [x] Verified `ccr stop` works correctly
- [x] Version shows 1.1.2

## Release Notes
After merging, this will be published as version 1.1.2 to npm.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `start` command now runs the server in the background by default.
  * Added a `--foreground` option to run the server in the foreground.

* **Enhancements**
  * Improved help text for the `start` command to clarify background and foreground options.
  * Added status messages and a spinner to indicate server startup progress and readiness.
  * Enhanced error handling during server startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->